### PR TITLE
reduced api setInterval() to resolve rate limit error

### DIFF
--- a/Assets/JS/iss.js
+++ b/Assets/JS/iss.js
@@ -78,7 +78,7 @@ const handleWeatherData = (data) => {
 getData();
 
 // Set interval to run getData function evey second to make marker move
-setInterval(getData, 1000);
+setInterval(getData, 5000);
 });
 
 // button event listener to render coordinates on page


### PR DESCRIPTION
noticed a 4XX error on gitpages due to max limit reached on api. I've reduced the set interval to 5 secs although the documentation allows roughly 1 sec. Hopefully this will resolve it, else i'll have to raise a support ticket with the api provider.